### PR TITLE
Set a proxy server for all API requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _testmain.go
 *.prof
 
 *.out
+
+# ignore Intellij products technical folder
+.idea/

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ func main() {
 
 ```
 
+# Does goinsta support proxy servers?
+Yes, you may create goinsta object using: 
+goinsta.NewViaProxy("USERNAME", "PASSWORD", "http://<ip>:<port>")
+
 # Thanks
 
 1. [levpasha](https://github.com/LevPasha)

--- a/goinsta.go
+++ b/goinsta.go
@@ -93,6 +93,12 @@ var GOINSTA_DEVICE_SETTINGS = map[string]interface{}{
 	"android_release": "4.3",
 }
 
+// All requests will use proxy server (example http://<ip>:<port>)
+func NewViaProxy(username, password, proxy string) *Instagram {
+	proxyUrl = proxy
+	return New(username, password)
+}
+
 // New try to fill Instagram struct
 // New does not try to login , it will only fill
 // Instagram struct

--- a/request.go
+++ b/request.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 )
 
 var (
@@ -12,6 +13,7 @@ var (
 	lastJson     string
 	cookie       string
 	cookiejar    *jar
+	proxyUrl     string
 )
 
 func (insta *Instagram) NewRequest(endpoint string, post string) error {
@@ -58,6 +60,14 @@ func (insta *Instagram) sendRequest(endpoint string, post string, login bool) er
 	client := &http.Client{
 		Jar: tempjar,
 	}
+	if proxyUrl != "" {
+		proxy, err := url.Parse(proxyUrl)
+		if err != nil {
+			return err
+		}
+		client.Transport = &http.Transport{Proxy: http.ProxyURL(proxy) }
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
Now you can set a proxy server for all API requests. It will help when you need some instances with different proxy servers