### PR TITLE
NewRequest & sendRequest methods of Instagram structure return []byte

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -15,7 +15,7 @@ func TestRequest(t *testing.T) {
 		return
 	}
 
-	err = insta.sendRequest("accounts/logout/", "", false)
+	_, err = insta.sendRequest("accounts/logout/", "", false)
 	if err != nil {
 		t.Fatal(err)
 		return


### PR DESCRIPTION
The methods return both []byte and err + refactoring related with errors, that will never be called

In some cases calling json.Marshal will never return ```err != nil```, so I have changed it to blank identifier