### PR TITLE
Add login methods correctly

### DIFF
--- a/goinsta.go
+++ b/goinsta.go
@@ -187,6 +187,17 @@ func (insta *Instagram) Login() error {
 		return err
 	}
 
+	insta.SyncFeatures()
+	insta.AutoCompleteUserList()
+	insta.GetRankedRecipients()
+	insta.Timeline()
+	insta.GetRankedRecipients()
+	insta.GetRecentRecipients()
+	insta.MegaphoneLog()
+	insta.GetV2Inbox()
+	insta.GetRecentActivity()
+	insta.GetReelsTrayFeed()
+
 	return nil
 }
 
@@ -281,6 +292,44 @@ func (insta *Instagram) MediaLikers(mediaId string) (response.MediaLikersRespons
 	err = json.Unmarshal(body, &resp)
 
 	return resp, err
+}
+
+// Simulate Instagram app behavior
+func (insta *Instagram) SyncFeatures() error {
+	bytes, err := json.Marshal(map[string]interface{}{
+		"_uuid":       insta.Informations.UUID,
+		"_uid":        insta.Informations.UsernameId,
+		"_csrftoken":  insta.Informations.Token,
+		"id":          insta.Informations.UsernameId,
+		"experiments": GOINSTA_EXPERIMENTS,
+	})
+
+	_, err = insta.sendRequest("qe/sync/", generateSignature(string(bytes)), false)
+	return err
+}
+
+// Simulate Instagram app behavior
+func (insta *Instagram) AutoCompleteUserList() error {
+	_, err := insta.sendRequest("friendships/autocomplete_user_list/?version=2", "", false, false)
+	return err
+}
+
+// Simulate Instagram app behavior
+func (insta *Instagram) MegaphoneLog() error {
+	bytes, err := json.Marshal(map[string]interface{}{
+		"_uid":       insta.Informations.UsernameId,
+		"id":         insta.Informations.UsernameId,
+		"type":       "feed_aysf",
+		"action":     "seen",
+		"reason":     "",
+		"_uuid":      insta.Informations.UUID,
+		"device_id":  insta.Informations.DeviceID,
+		"_csrftoken": insta.Informations.Token,
+		"uuid":       generateMD5Hash(string(time.Now().Unix())),
+	})
+
+	_, err = insta.sendRequest("qe/sync/", generateSignature(string(bytes)), false)
+	return err
 }
 
 // Expose , expose instagram

--- a/goinsta.go
+++ b/goinsta.go
@@ -167,26 +167,6 @@ func (insta *Instagram) Login() error {
 	insta.IsLoggedIn = true
 	insta.LoggedInUser = Result.LoggedInUser
 
-	bytes, err := json.Marshal(map[string]interface{}{
-		"_uuid":       insta.Informations.UUID,
-		"_uid":        insta.Informations.UsernameId,
-		"_csrftoken":  insta.Informations.Token,
-		"id":          insta.Informations.UsernameId,
-		"experiments": GOINSTA_EXPERIMENTS,
-	})
-
-	// Simulate Instagram app behavior
-	_, err = insta.sendRequest("qe/sync/", generateSignature(string(bytes)), false)
-	if err != nil {
-		return err
-	}
-
-	// Simulate Instagram app behavior
-	_, err = insta.sendRequest("friendships/autocomplete_user_list/?version=2", "", false, false)
-	if err != nil {
-		return err
-	}
-
 	insta.SyncFeatures()
 	insta.AutoCompleteUserList()
 	insta.GetRankedRecipients()

--- a/goinsta.go
+++ b/goinsta.go
@@ -274,7 +274,7 @@ func (insta *Instagram) MediaLikers(mediaId string) (response.MediaLikersRespons
 	return resp, err
 }
 
-// Simulate Instagram app behavior
+// SyncFeatures simulates Instagram app behavior
 func (insta *Instagram) SyncFeatures() error {
 	bytes, err := json.Marshal(map[string]interface{}{
 		"_uuid":       insta.Informations.UUID,
@@ -288,13 +288,13 @@ func (insta *Instagram) SyncFeatures() error {
 	return err
 }
 
-// Simulate Instagram app behavior
+// AutoCompleteUserList simulates Instagram app behavior
 func (insta *Instagram) AutoCompleteUserList() error {
 	_, err := insta.sendRequest("friendships/autocomplete_user_list/?version=2", "", false, false)
 	return err
 }
 
-// Simulate Instagram app behavior
+// MegaphoneLog simulates Instagram app behavior
 func (insta *Instagram) MegaphoneLog() error {
 	bytes, err := json.Marshal(map[string]interface{}{
 		"_uid":       insta.Informations.UsernameId,

--- a/goinsta.go
+++ b/goinsta.go
@@ -308,7 +308,7 @@ func (insta *Instagram) MegaphoneLog() error {
 		"uuid":       generateMD5Hash(string(time.Now().Unix())),
 	})
 
-	_, err = insta.sendRequest("qe/sync/", generateSignature(string(bytes)), false)
+	_, err = insta.sendRequest("megaphone/log/", generateSignature(string(bytes)), false)
 	return err
 }
 

--- a/goinsta_test.go
+++ b/goinsta_test.go
@@ -555,3 +555,39 @@ func TestLogout(t *testing.T) {
 
 	t.Log("status : ok")
 }
+
+func TestSyncFeatures(t *testing.T) {
+	if skip {
+		t.Skip("Empty username or password , Skipping ...")
+	}
+	err := insta.SyncFeatures()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	t.Log("status : ok")
+}
+
+func TestAutoCompleteUserList(t *testing.T) {
+	if skip {
+		t.Skip("Empty username or password , Skipping ...")
+	}
+	err := insta.AutoCompleteUserList()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	t.Log("status : ok")
+}
+
+func TestMegaphoneLog(t *testing.T) {
+	if skip {
+		t.Skip("Empty username or password , Skipping ...")
+	}
+	err := insta.MegaphoneLog()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	t.Log("status : ok")
+}


### PR DESCRIPTION
Fixes https://github.com/ahmdrz/goinsta/pull/15 which I didn't achieve my actual goal.

After investigating and testing `mgp25/Instagram-API` behaviour, I tried to fix it again and this time it works perfectly. It's now fetching new feed no matter what method you use. These functions are added inspired by PHP lib:

````
            $this->syncFeatures();
            $this->autoCompleteUserList();
            $this->timelineFeed();
            $this->getRankedRecipients();
            $this->getRecentRecipients();
            $this->megaphoneLog();
            $this->getv2Inbox();
            $this->getRecentActivity();
            $this->getReelsTrayFeed();
````

Notes:
- We are still not returning `$this->explore()`. I'll make another PR soon to make it more complete.
- Login now takes a little bit more time, but you can handle repeated login just like before manually. I'm using it on production now so I have to implement it soon too.

I tested and works fine but I encourage you guys do some tests too.