### PR TITLE
fix failed login fatal error

### DIFF
--- a/goinsta.go
+++ b/goinsta.go
@@ -4,6 +4,7 @@ package goinsta
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image"
 	_ "image/jpeg"
@@ -134,7 +135,11 @@ func (insta *Instagram) Login() error {
 	}
 
 	data := insta.cookie[strings.Index(insta.cookie, "csrftoken=")+10:]
-	data = data[:strings.Index(data, ";")]
+	if len(data) != 6 {
+		data = data[:strings.Index(data, ";")]
+	} else {
+		return errors.New("Instagram regected login due to many logins, try again in few minutes.")
+	}
 
 	result, _ := json.Marshal(map[string]interface{}{
 		"guid":                insta.Informations.UUID,


### PR DESCRIPTION
fixes #32 preventing a fatal exit.

Problem happens when logins happen often and Instagram sometimes reject them, this is supposed to happen and needs to be handled to retry another login by developer. However current error handling doesn't provide anything and instead there's an error during cookie assignment.

while requesting headers at login
````
request:  si/fetch_headers/?challenge_type=signup&guid=afd5344e-8c1a-4b9d-a228-7eed052bf928
````
cookie returned when instagram regects
````
cookie:  rur=PRN; Path=/
body:  {"status": "ok"}
````
cookie returned when Instagram accepts (supposed to have it)
````
mid=WONV_QABAAFUmj-wQmjpxLm_VFpx; expires=Mon, 30-Mar-2037 08:14:53 GMT; Max-Age=630720000; Path=/
````
Fatal error that happens:
````
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/ahmdrz/goinsta.(*Instagram).Login(0x130d0b80, 0x1313fe08, 0x1)
        /~/go/src/github.com/ahmdrz/goinsta/goinsta.go:141 +0xdd2
main.main()
       /~/go/src/go-insta/main.go:103 +0x1c47
````