### PR TITLE
Support ReelsTray endpoints

### DIFF
--- a/goinsta.go
+++ b/goinsta.go
@@ -1069,16 +1069,34 @@ func (insta *Instagram) DirectMessage(recipient string, message string) (respons
 	return result, nil
 }
 
-func (insta *Instagram) GetReelsTrayFeed() {
-	insta.sendRequest("feed/reels_tray/", "", false)
+// GetTrayFeeds - Get all available Instagram stories of your friends
+func (insta *Instagram) GetReelsTrayFeed() (response.TrayResponse, error) {
+	bytes, err := insta.sendRequest("feed/reels_tray/", "", false)
+	if err != nil {
+		return response.TrayResponse{}, err
+	}
+
+	result := response.TrayResponse{}
+	json.Unmarshal([]byte(bytes), &result)
+
+	return result, nil
 }
 
-func (insta *Instagram) GetTrayFeeds(id string) {
-	insta.sendRequest("feed/reels_tray/?tray_session_id="+id, "", false)
-}
+// GetUserStories - Get all available Instagram stories for the given user id
+func (insta *Instagram) GetUserStories(id string) (response.TrayUserResponse, error) {
+	if id == "" {
+		return response.TrayUserResponse{}, nil
+	}
 
-func (insta *Instagram) GetUserStories(id string) {
-	insta.sendRequest("feed/user/"+id+"/reel_media", "", false)
+	bytes, err := insta.sendRequest("feed/user/"+id+"/reel_media/", "", false)
+	if err != nil {
+		return response.TrayUserResponse{}, err
+	}
+
+	result := response.TrayUserResponse{}
+	json.Unmarshal([]byte(bytes), &result)
+
+	return result, nil
 }
 
 func (insta *Instagram) UserFriendShip(userid interface{}) (response.UserFriendShipResponse, error) {

--- a/goinsta_test.go
+++ b/goinsta_test.go
@@ -352,6 +352,23 @@ func TestGetUserID(t *testing.T) {
 	t.Log("ok")
 }
 
+func TestGetReelsTray(t *testing.T) {
+	if skip {
+		t.Skip("Empty username or password , Skipping ...")
+	}
+
+	resp, err := insta.GetReelsTrayFeed()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Status != "ok" {
+		t.Fatalf("Incorrect status" + resp.Status)
+	}
+
+	t.Log(resp.Status)
+}
+
 func TestGetUsername(t *testing.T) {
 	if skip {
 		t.Skip("Empty username or password , Skipping ...")

--- a/response/types.go
+++ b/response/types.go
@@ -1471,3 +1471,216 @@ type FollowingRecentActivityResponse struct {
 		} `json:"args"`
 	} `json:"stories"`
 }
+
+type TrayResponse struct {
+	Status string `json:"status"`
+	Tray   []struct {
+		CanReply   bool `json:"can_reply"`
+		ExpiringAt int  `json:"expiring_at"`
+		User       struct {
+			Username         string `json:"username"`
+			FriendshipStatus struct {
+				IncomingRequest bool `json:"incoming_request"`
+				FollowedBy      bool `json:"followed_by"`
+				OutgoingRequest bool `json:"outgoing_request"`
+				Following       bool `json:"following"`
+				Blocking        bool `json:"blocking"`
+				IsPrivate       bool `json:"is_private"`
+			} `json:"friendship_status"`
+			ProfilePicURL string `json:"profile_pic_url"`
+			ProfilePicID  string `json:"profile_pic_id"`
+			FullName      string `json:"full_name"`
+			Pk            int    `json:"pk"`
+			IsVerified    bool   `json:"is_verified"`
+			IsPrivate     bool   `json:"is_private"`
+		} `json:"user"`
+		ID                 int `json:"id"`
+		LatestReelMedia    int `json:"latest_reel_media"`
+		Seen               int `json:"seen"`
+		RankedPosition     int `json:"ranked_position"`
+		SeenRankedPosition int `json:"seen_ranked_position"`
+		Muted              int `json:"muted"`
+		Media              []struct {
+			TakenAt         int    `json:"taken_at"`
+			Pk              int64  `json:"pk"`
+			ID              string `json:"id"`
+			DeviceTimestamp int64  `json:"device_timestamp"`
+			MediaType       int    `json:"media_type"`
+			Code            string `json:"code"`
+			ClientCacheKey  string `json:"client_cache_key"`
+			FilterType      int    `json:"filter_type"`
+			ImageVersions2  struct {
+				Candidates []struct {
+					URL    string `json:"url"`
+					Width  int    `json:"width"`
+					Height int    `json:"height"`
+				} `json:"candidates"`
+			} `json:"image_versions2"`
+			OriginalWidth  int  `json:"original_width"`
+			OriginalHeight int  `json:"original_height"`
+			HasAudio       bool `json:"has_audio"`
+			VideoVersions  []struct {
+				URL    string `json:"url"`
+				Type   int    `json:"type"`
+				Height int    `json:"height"`
+				Width  int    `json:"width"`
+			} `json:"video_versions"`
+			User struct {
+				Username                   string `json:"username"`
+				HasAnonymousProfilePicture bool   `json:"has_anonymous_profile_picture"`
+				IsUnpublished              bool   `json:"is_unpublished"`
+				IsFavorite                 bool   `json:"is_favorite"`
+				FriendshipStatus           struct {
+					Following       bool `json:"following"`
+					OutgoingRequest bool `json:"outgoing_request"`
+				} `json:"friendship_status"`
+				ProfilePicURL string `json:"profile_pic_url"`
+				ProfilePicID  string `json:"profile_pic_id"`
+				FullName      string `json:"full_name"`
+				Pk            int    `json:"pk"`
+				IsVerified    bool   `json:"is_verified"`
+				IsPrivate     bool   `json:"is_private"`
+			} `json:"user"`
+			OrganicTrackingToken         string `json:"organic_tracking_token"`
+			LikeCount                    int    `json:"like_count"`
+			HasLiked                     bool   `json:"has_liked"`
+			HasMoreComments              bool   `json:"has_more_comments"`
+			NextMaxID                    int64  `json:"next_max_id"`
+			MaxNumVisiblePreviewComments int    `json:"max_num_visible_preview_comments"`
+			PreviewComments              []struct {
+				Status       string `json:"status"`
+				UserID       int    `json:"user_id"`
+				CreatedAtUtc int    `json:"created_at_utc"`
+				CreatedAt    int    `json:"created_at"`
+				BitFlags     int    `json:"bit_flags"`
+				User         struct {
+					Username      string `json:"username"`
+					ProfilePicURL string `json:"profile_pic_url"`
+					ProfilePicID  string `json:"profile_pic_id"`
+					FullName      string `json:"full_name"`
+					Pk            int    `json:"pk"`
+					IsVerified    bool   `json:"is_verified"`
+					IsPrivate     bool   `json:"is_private"`
+				} `json:"user"`
+				ContentType string `json:"content_type"`
+				Text        string `json:"text"`
+				MediaID     int64  `json:"media_id"`
+				Pk          int64  `json:"pk"`
+				Type        int    `json:"type"`
+			} `json:"preview_comments"`
+			CommentCount int `json:"comment_count"`
+			Caption      struct {
+				Status       string `json:"status"`
+				UserID       int    `json:"user_id"`
+				CreatedAtUtc int    `json:"created_at_utc"`
+				CreatedAt    int    `json:"created_at"`
+				BitFlags     int    `json:"bit_flags"`
+				User         struct {
+					Username                   string `json:"username"`
+					HasAnonymousProfilePicture bool   `json:"has_anonymous_profile_picture"`
+					IsUnpublished              bool   `json:"is_unpublished"`
+					IsFavorite                 bool   `json:"is_favorite"`
+					FriendshipStatus           struct {
+						Following       bool `json:"following"`
+						OutgoingRequest bool `json:"outgoing_request"`
+					} `json:"friendship_status"`
+					ProfilePicURL string `json:"profile_pic_url"`
+					ProfilePicID  string `json:"profile_pic_id"`
+					FullName      string `json:"full_name"`
+					Pk            int    `json:"pk"`
+					IsVerified    bool   `json:"is_verified"`
+					IsPrivate     bool   `json:"is_private"`
+				} `json:"user"`
+				ContentType    string `json:"content_type"`
+				Text           string `json:"text"`
+				MediaID        int64  `json:"media_id"`
+				Pk             int64  `json:"pk"`
+				HasTranslation bool   `json:"has_translation"`
+				Type           int    `json:"type"`
+			} `json:"caption"`
+			CaptionIsEdited    bool   `json:"caption_is_edited"`
+			PhotoOfYou         bool   `json:"photo_of_you"`
+			Algorithm          string `json:"algorithm"`
+			ExploreContext     string `json:"explore_context"`
+			ExploreSourceToken string `json:"explore_source_token"`
+			Explore            struct {
+				Explanation string `json:"explanation"`
+				ActorID     int    `json:"actor_id"`
+				SourceToken string `json:"source_token"`
+			} `json:"explore"`
+			ImpressionToken string `json:"impression_token"`
+		} `json:"items"`
+	} `json:"tray"`
+}
+
+// TrayUserResponse - Response for specific user tray
+type TrayUserResponse struct {
+	Status     string `json:"status"`
+	CanReply   bool   `json:"can_reply"`
+	ExpiringAt int    `json:"expiring_at"`
+	User       struct {
+		Username         string `json:"username"`
+		FriendshipStatus struct {
+			IncomingRequest bool `json:"incoming_request"`
+			FollowedBy      bool `json:"followed_by"`
+			OutgoingRequest bool `json:"outgoing_request"`
+			Following       bool `json:"following"`
+			Blocking        bool `json:"blocking"`
+			IsPrivate       bool `json:"is_private"`
+		} `json:"friendship_status"`
+		ProfilePicURL string `json:"profile_pic_url"`
+		ProfilePicID  string `json:"profile_pic_id"`
+		FullName      string `json:"full_name"`
+		Pk            int    `json:"pk"`
+		IsVerified    bool   `json:"is_verified"`
+		IsPrivate     bool   `json:"is_private"`
+	} `json:"user"`
+	ID                 int `json:"id"`
+	LatestReelMedia    int `json:"latest_reel_media"`
+	Seen               int `json:"seen"`
+	RankedPosition     int `json:"ranked_position"`
+	SeenRankedPosition int `json:"seen_ranked_position"`
+	Muted              int `json:"muted"`
+	Media              []struct {
+		TakenAt         int    `json:"taken_at"`
+		Pk              int64  `json:"pk"`
+		ID              string `json:"id"`
+		DeviceTimestamp int64  `json:"device_timestamp"`
+		MediaType       int    `json:"media_type"`
+		Code            string `json:"code"`
+		ClientCacheKey  string `json:"client_cache_key"`
+		FilterType      int    `json:"filter_type"`
+		ImageVersions2  struct {
+			Candidates []struct {
+				URL    string `json:"url"`
+				Width  int    `json:"width"`
+				Height int    `json:"height"`
+			} `json:"candidates"`
+		} `json:"image_versions2"`
+		OriginalWidth  int  `json:"original_width"`
+		OriginalHeight int  `json:"original_height"`
+		HasAudio       bool `json:"has_audio"`
+		VideoVersions  []struct {
+			URL    string `json:"url"`
+			Type   int    `json:"type"`
+			Height int    `json:"height"`
+			Width  int    `json:"width"`
+		} `json:"video_versions"`
+		User struct {
+			Username                   string `json:"username"`
+			HasAnonymousProfilePicture bool   `json:"has_anonymous_profile_picture"`
+			IsUnpublished              bool   `json:"is_unpublished"`
+			IsFavorite                 bool   `json:"is_favorite"`
+			FriendshipStatus           struct {
+				Following       bool `json:"following"`
+				OutgoingRequest bool `json:"outgoing_request"`
+			} `json:"friendship_status"`
+			ProfilePicURL string `json:"profile_pic_url"`
+			ProfilePicID  string `json:"profile_pic_id"`
+			FullName      string `json:"full_name"`
+			Pk            int    `json:"pk"`
+			IsVerified    bool   `json:"is_verified"`
+			IsPrivate     bool   `json:"is_private"`
+		} `json:"user"`
+	} `json:"media"`
+}


### PR DESCRIPTION
This commit adds support for ReelsTray aka Instagram Stories. You can
fetch either all friends stories or all available stories for a given
user id.