### PR TITLE
Add API endpoints to disable/enable comments for a given MediaID

### DIFF
--- a/goinsta.go
+++ b/goinsta.go
@@ -838,6 +838,34 @@ func (insta *Instagram) UnLike(mediaID string) ([]byte, error) {
 	})
 }
 
+func (insta *Instagram) DisableComments(mediaID string) ([]byte, error) {
+	data, err := insta.prepareData(map[string]interface{}{
+		"media_id": mediaID,
+	})
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return insta.sendRequest(&reqOptions{
+		Endpoint: fmt.Sprintf("media/%s/disable_comments/", mediaID),
+		PostData: generateSignature(data),
+	})
+}
+
+func (insta *Instagram) EnableComments(mediaID string) ([]byte, error) {
+	data, err := insta.prepareData(map[string]interface{}{
+		"media_id": mediaID,
+	})
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return insta.sendRequest(&reqOptions{
+		Endpoint: fmt.Sprintf("media/%s/enable_comments/", mediaID),
+		PostData: generateSignature(data),
+	})
+}
+
 func (insta *Instagram) EditMedia(mediaID string, caption string) ([]byte, error) {
 	data, err := insta.prepareData(map[string]interface{}{
 		"caption_text": caption,


### PR DESCRIPTION
recently I needed to disable comments to all new uploads I make,
so I've added two endpoints: 
`media/%s/disable_comments/` and `media/%s/enable_comments/`

I hope this proves to be useful for someone else 😉

P.S.: I had to decompile the instagram apk in order to get these urls as Instagram uses SSL pinning to prevent tools like Charles from traffic sniffing. 