### PR TITLE
Use json.Number for next_max_id

### DIFF
--- a/media.go
+++ b/media.go
@@ -735,6 +735,8 @@ func (media *FeedMedia) ID() string {
 		return s
 	case int64:
 		return strconv.FormatInt(s, 10)
+	case json.Number:
+		return string(s)
 	}
 	return ""
 }
@@ -783,7 +785,9 @@ func (media *FeedMedia) Next(params ...interface{}) bool {
 	)
 	if err == nil {
 		m := FeedMedia{}
-		err = json.Unmarshal(body, &m)
+		d := json.NewDecoder(bytes.NewReader(body))
+		d.UseNumber()
+		err = d.Decode(&m)
 		if err == nil {
 			*media = m
 			media.inst = insta


### PR DESCRIPTION
The changes I have made fixes #151 .

By default unmarshaling converts next_max_id field to float64 from the response of liked items request. Because of that, `ID()` func can not return correct response. I tried to handle replace float64 with string in that func with `fmt.Sprintf("%.0f", s)` but it gives wrong number. So, I use json decoder instead of `Unmarshal` method and configured it to use numbers. 