### PR TITLE
Add v2 suffix in go.mod module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/ahmdrz/goinsta
+module github.com/ahmdrz/goinsta.v2


### PR DESCRIPTION
Hello,

Since the release of go 1.11 I'm unable to make the lib work because of invalid `go.mod`:

```
go: gopkg.in/ahmdrz/goinsta.v2@v2.0.0-20180703233155-8a4b1078ad1b: go.mod has non-....v2 module path "github.com/ahmdrz/goinsta" at revision 8a4b1078ad1b
go: error loading module requirements
```

Here is a simple PR to add the missing v2 suffix.

Note I'm directly targeting master branch instead of alpha since it's not a functional change. Tell me if you want me to change that.