### PR TITLE
Media sync

### DIFF
--- a/media.go
+++ b/media.go
@@ -701,7 +701,7 @@ func (media *FeedMedia) Sync() error {
 		&reqOptions{
 			Endpoint: fmt.Sprintf(urlMediaInfo, id),
 			Query:    generateSignature(data),
-			IsPost:   true,
+			IsPost:   false,
 		},
 	)
 	if err != nil {

--- a/media.go
+++ b/media.go
@@ -677,6 +677,11 @@ func (media *FeedMedia) instagram() *Instagram {
 	return media.inst
 }
 
+// SetInstagram set instagram
+func (media *FeedMedia) SetInstagram(inst *Instagram) {
+	media.inst = inst
+}
+
 // SetID sets media ID
 // this value can be int64 or string
 func (media *FeedMedia) SetID(id interface{}) {


### PR DESCRIPTION
Hi,

This patch:
 * fix a 405 error on media.Sync error when request method is Post.
 * Add a setter for instagram on instagram

This patch allow developer to request a feedMedia from mediaID

Example:
```
insta := goinsta.New("USERNAME", "PASSWORD")
media := &goinsta.FeedMedia{}
media.SetID("mediaID")
media.SetInstagram(insta)
err := media.Sync()
```