### PR TITLE
Updated go.mod path to /v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/ahmdrz/goinsta.v2
+module github.com/ahmdrz/goinsta/v2


### PR DESCRIPTION
Go modules require use of [semver](https://semver.org/) tags (vX.Y.Z) and `/vX` in the module path for version `>=v1`.

I've created a tag `v2.4.0` in the fork, which seems to be in line with the package version. It can be tested using the `replace` directive:

```go
require github.com/ahmdrz/goinsta/v2 v2.4.0
replace github.com/ahmdrz/goinsta/v2 => github.com/krylovsk/goinsta/v2 v2.4.0
```

This fixes #193 