### PR TITLE
Fix interface{} unmarshalling

### DIFF
--- a/media.go
+++ b/media.go
@@ -409,16 +409,37 @@ func (item *Item) TopLikers() []string {
 // If PreviewComments are string or []string only the Text field will be filled.
 func (item *Item) PreviewComments() []Comment {
 	switch s := item.Previewcomments.(type) {
-	case []Comment:
-		return s
-	case []string:
-		comments := make([]Comment, 0)
-		for i := range s {
-			comments = append(comments, Comment{
-				Text: s[i],
-			})
+	case []interface{}:
+		if len(s) == 0 {
+			return nil
 		}
-		return comments
+
+		switch s[0].(type) {
+		case interface{}:
+			comments := make([]Comment, 0)
+			for i := range s {
+				if buf, err := json.Marshal(s[i]); err != nil {
+					return nil
+				} else {
+					comment := &Comment{}
+
+					if err = json.Unmarshal(buf, comment); err != nil {
+						return nil
+					} else {
+						comments = append(comments, *comment)
+					}
+				}
+			}
+			return comments
+		case string:
+			comments := make([]Comment, 0)
+			for i := range s {
+				comments = append(comments, Comment{
+					Text: s[i].(string),
+				})
+			}
+			return comments
+		}
 	case string:
 		comments := []Comment{
 			{


### PR DESCRIPTION
Hello all,

Here it is a small bugfix for item.PreviewComments(). Problem was the default types that the json package Unmarshals into. Since you're unmarshaling Previewcomments into an interface{}, the returned types will only be from (https://golang.org/pkg/encoding/json/#Unmarshal):

bool, for JSON booleans
float64, for JSON numbers
string, for JSON strings
[]interface{}, for JSON arrays
map[string]interface{}, for JSON objects
nil for JSON null

The json package doesn't know about []Comment and []String in PreviewComments(), so this function did nothing in these cases. We either need to convert from the map[string]interface{} that the json object is being unmarshaled into, or unmarshal directly into the intended struct type.

Regards,
