### PR TITLE
Improves hashtags isolation/recognition

### DIFF
--- a/media.go
+++ b/media.go
@@ -188,7 +188,7 @@ func GetBest(obj interface{}) string {
 	return m.url
 }
 
-var rxpTags *regexp.Regexp
+var rxpTags = regexp.MustCompile(`#\w+`)
 
 // Hashtags returns caption hashtags.
 //
@@ -935,8 +935,4 @@ func (insta *Instagram) UploadPhoto(photo io.Reader, photoCaption string, qualit
 	}
 
 	return uploadResult.Media, nil
-}
-
-func init() {
-	rxpTags = regexp.MustCompile(`#\w+`)
 }


### PR DESCRIPTION
Hello,

I found the item.Hashtags() was missing some hashtags and/or collapsing many of them on a single slot. This patch fixes it through a regexp-based approach. Besides, it also looks into the Previewcomments field (see pull request #209) in order to scrape as much hashtags as possible with no extra ig interaction.

Best,
