### PR TITLE
Fixed proxy leakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 * **Security**. Your password is only required to login. After login your password is deleted.
 * **No External Dependencies**. GoInsta will not use any Go packages outside of the standard library.
 
-### Package installation 
+### Package installation
 
 `go get -u -v gopkg.in/ahmdrz/goinsta.v2`
 
@@ -39,6 +39,8 @@ import (
 
 func main() {
   //insta, err := goinsta.Import("~/.goinsta")
+  //insta.SetProxy("http://localhost:8080", true) // true for insecure connections
+  //insta.ImportSync()
   insta := goinsta.New("USERNAME", "PASSWORD")
 
   // also you can use New function from gopkg.in/ahmdrz/goinsta.v2/utils

--- a/examples/contacts/sync.go
+++ b/examples/contacts/sync.go
@@ -7,6 +7,7 @@ import (
 
 func main() {
 	//insta, _ := goinsta.Import("session_dump")
+	//insta.ImportSync()
 	insta := goinsta.New("lnsta_login", "insta_passwordd")
 
 	// also you can use New function from gopkg.in/ahmdrz/goinsta.v2/utils

--- a/examples/goinstaExamples.go
+++ b/examples/goinstaExamples.go
@@ -43,6 +43,7 @@ func InitGoinsta(msg string) (*goinsta.Instagram, error) {
 		if err != nil {
 			return nil, err
 		}
+		inst.ImportSync()
 
 		UsingSession = true
 	} else {

--- a/goinsta.go
+++ b/goinsta.go
@@ -234,7 +234,6 @@ func ImportReader(r io.Reader) (*Instagram, error) {
 
 	inst.init()
 	inst.Account = &Account{inst: inst, ID: config.ID}
-	inst.Account.Sync()
 
 	return inst, nil
 }
@@ -249,6 +248,13 @@ func Import(path string) (*Instagram, error) {
 	}
 	defer f.Close()
 	return ImportReader(f)
+}
+
+// ImportSync synchronizes the instagram configuration with the server
+//
+// Must be called *after* SetProxy in order to prevent packet leaks.
+func (inst *Instagram) ImportSync() {
+	inst.Account.Sync()
 }
 
 func (inst *Instagram) readMsisdnHeader() error {

--- a/utils/util.go
+++ b/utils/util.go
@@ -29,6 +29,7 @@ func New() *goinsta.Instagram {
 			fmt.Println(err)
 			os.Exit(1)
 		}
+		inst.ImportSync()
 		return inst
 	}
 


### PR DESCRIPTION
Hi all, 

Using SetProxy() after Import() produced a packet leakage on the real IP. In my setup this contributed to trig the checkpoint_challenge_required issue (see #188).

Among the several possible, this patch tries to keep things as simple as possible though a two-steps approach to Import():

insta, err := goinsta.Import("~/.goinsta")
insta.SetProxy("http://localhost:8080", true) // true for insecure connections
insta.ImportSync()

Best,
