### PR TITLE
Added a HTTP client setter for Instagram struct

### DIFF
--- a/goinsta.go
+++ b/goinsta.go
@@ -67,7 +67,9 @@ type Instagram struct {
 	c *http.Client
 }
 
-// SetHTTPClient sets http client
+// SetHTTPClient sets http client.  This further allows users to use this functionality
+// for HTTP testing using a mocking HTTP client Transport, which avoids direct calls to
+// the Instagram, instead of returning mocked responses.
 func (inst *Instagram) SetHTTPClient(client *http.Client) {
 	inst.c = client
 }

--- a/goinsta.go
+++ b/goinsta.go
@@ -67,6 +67,11 @@ type Instagram struct {
 	c *http.Client
 }
 
+// SetHTTPClient sets http client
+func (inst *Instagram) SetHTTPClient(client *http.Client) {
+	inst.c = client
+}
+
 // SetDeviceID sets device id
 func (inst *Instagram) SetDeviceID(id string) {
 	inst.dID = id


### PR DESCRIPTION
Adding a setter to the Instagram struct allows users to set a custom HTTP client, other than the default one created in New(). This further allows users to use this functionality for HTTP testing, using a mocking HTTP client Transport, which avoids direct calls to Instagram, instead returning mocked responses.