### PR TITLE
Added support for Story Audience tag in Item

### DIFF
--- a/media.go
+++ b/media.go
@@ -485,9 +485,9 @@ func (item *Item) PreviewComments() []Comment {
 	return nil
 }
 
-// StoryCloseFriends returns a bool
+// StoryIsCloseFriends returns a bool
 // If the returned value is true the story was published only for close friends
-func (item *Item) StoryCloseFriends() bool {
+func (item *Item) StoryIsCloseFriends() bool {
 	return item.Audience == "besties"
 }
 

--- a/media.go
+++ b/media.go
@@ -127,6 +127,7 @@ type Item struct {
 	ShowOneTapFbShareTooltip bool               `json:"show_one_tap_fb_share_tooltip"`
 	HasSharedToFb            int64              `json:"has_shared_to_fb"`
 	Mentions                 []Mentions
+	Audience                 string `json:"audience,omitempty"`
 }
 
 // MediaToString returns Item.MediaType as string.
@@ -482,6 +483,12 @@ func (item *Item) PreviewComments() []Comment {
 		return comments
 	}
 	return nil
+}
+
+// StoryCloseFriends returns a bool
+// If the returned value is true the story was published only for close friends
+func (item *Item) StoryCloseFriends() bool {
+	return item.Audience == "besties"
 }
 
 //Media interface defines methods for both StoryMedia and FeedMedia.


### PR DESCRIPTION
Hi, I was working on Instagram's Stories and I noticed that there is no way to detect whenever a story is pubblished only to close friends: So I dumped the JSON Response and added the `audience` tag to the Item struct. I also added the `StoryCloseFriends` method on the Item struct.