### PR TITLE
Assign missing value to Image's media attribute

### DIFF
--- a/feeds.go
+++ b/feeds.go
@@ -79,6 +79,14 @@ func (feed *Feed) Tags(tag string) (*FeedTag, error) {
 			NextID: res.RankedItems[i].ID,
 		}
 	}
+
+	for i := range res.Images {
+		res.Images[i].media = &FeedMedia{
+			inst:   insta,
+			NextID: res.Images[i].ID,
+		}
+	}
+
 	return res, nil
 }
 


### PR DESCRIPTION
Currently, if you range over the items present in `*goinsta.FeedTag.Images` and try to call the `Like` method on an item. The program will crash due to the media attribute being equal to `nil`. 

This PR fixes this issue by assigning a `&FeedMedia` to the item's media attribute.