### PR TITLE
Fixed Invalid Status Code for FriendShip in users.go

### DIFF
--- a/users.go
+++ b/users.go
@@ -453,7 +453,6 @@ func (user *User) FriendShip() error {
 		&reqOptions{
 			Endpoint: fmt.Sprintf(urlFriendship, user.ID),
 			Query:    generateSignature(data),
-			IsPost:   true,
 		},
 	)
 	if err == nil {


### PR DESCRIPTION
Fixed Invalid status code: 405 for FriendShip(), method is changed from post to get