### PR TITLE
Add type "carousel" to `MediaToString()` function

### DIFF
--- a/media.go
+++ b/media.go
@@ -176,6 +176,8 @@ func (item *Item) MediaToString() string {
 		return "photo"
 	case 2:
 		return "video"
+	case 8:
+		return "carousel"
 	}
 	return ""
 }


### PR DESCRIPTION
Posts with carousel have empty `Images` and `Videos`, so we have to extract the images/videos from `CarouselMedia`, but one cannot determine post type simply by calling `MediaToString()`. 

Adding this helps users determining the post type as `carousel` instead of checking for `MediaType` (int) for better readability.