### PR TITLE
Fix empty errors on login challenge

### DIFF
--- a/types.go
+++ b/types.go
@@ -58,11 +58,16 @@ type Error400 struct {
 		ClientContext string `json:"client_context"`
 		Message       string `json:"message"`
 	} `json:"payload"`
-	Status string `json:"status"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
 }
 
 func (e Error400) Error() string {
-	return fmt.Sprintf("%s: %s", e.Status, e.Payload.Message)
+	var message = e.Payload.Message
+	if message == "" {
+		message = e.Message
+	}
+	return fmt.Sprintf("%s: %s", e.Status, message)
 }
 
 // ChallengeError is error returned by HTTP 400 status code.


### PR DESCRIPTION
Some errors, like the login challenge error, have the message in the first level, not under the payload
I haven't created a test because the standard example of login challenge works fine for it.

If for some reason the code is not accepted, the message of the error in in the first level of the body. I think multiple errors are like this.

