### PR TITLE
fix(): Fix nil pointer panic in verification example

### DIFF
--- a/examples/verification/main.go
+++ b/examples/verification/main.go
@@ -40,9 +40,14 @@ func main() {
 			if err != nil {
 				log.Fatalln(err)
 			}
+
+			insta.Account = insta.Challenge.LoggedInUser
+		default:
+			log.Fatalln(err)
 		}
 
-		log.Fatalln(err)
+		log.Printf("logged in as %s \n", insta.Account.Username)
 	}
+
 	defer insta.Logout()
 }


### PR DESCRIPTION
After completing challenge Account at root structure stayed to be nil. That cases panic.
Assign Account from Challenge to root Account