### PR TITLE
Instagram reference added to user search result

### DIFF
--- a/search.go
+++ b/search.go
@@ -95,6 +95,9 @@ func (search *Search) User(user string, countParam ...int) (*SearchResult, error
 
 	res := &SearchResult{}
 	err = json.Unmarshal(body, res)
+	for id := range res.Users {
+		res.Users[id].inst = insta
+	}
 	return res, err
 }
 


### PR DESCRIPTION
When you search users, search result returns instagram object reference as nil therefore you cant be able to sync users.