### PR TITLE
Current user sync url fixed

### DIFF
--- a/const.go
+++ b/const.go
@@ -44,7 +44,7 @@ const (
 	urlExpose         = "qe/expose/"
 
 	// account
-	urlCurrentUser   = "accounts/current_user/"
+	urlCurrentUser   = "accounts/current_user/?edit=true"
 	urlChangePass    = "accounts/change_password/"
 	urlSetPrivate    = "accounts/set_private/"
 	urlSetPublic     = "accounts/set_public/"

--- a/search.go
+++ b/search.go
@@ -95,6 +95,9 @@ func (search *Search) User(user string, countParam ...int) (*SearchResult, error
 
 	res := &SearchResult{}
 	err = json.Unmarshal(body, res)
+	for id := range res.Users {
+		res.Users[id].inst = insta
+	}
 	return res, err
 }
 


### PR DESCRIPTION
When syncing current user's info url should be "accounts/current_user/?edit=true"