### PR TITLE
Specify the correct insta account after passing the verification

### DIFF
--- a/challenge.go
+++ b/challenge.go
@@ -130,6 +130,8 @@ func (challenge *Challenge) SendSecurityCode(code string) error {
 		if err == nil {
 			*challenge = *resp.Challenge
 			challenge.insta = insta
+			challenge.LoggedInUser.inst = insta
+			insta.Account = challenge.LoggedInUser
 		}
 	}
 	return err


### PR DESCRIPTION
After passing the verification, the insta.Account attribute equals nil, so it's impossible to use the insta.Account methods. This only happens if the challenge required. After config importing or successful login, everything is fine.