### PR TITLE
Fix build error for int to string conversion

### DIFF
--- a/goinsta.go
+++ b/goinsta.go
@@ -3,6 +3,7 @@ package goinsta
 import (
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -484,7 +485,7 @@ func (inst *Instagram) megaphoneLog() error {
 			"action":    "seen",
 			"reason":    "",
 			"device_id": inst.dID,
-			"uuid":      generateMD5Hash(string(time.Now().Unix())),
+			"uuid":      generateMD5Hash(fmt.Sprint(time.Now().Unix())),
 		},
 	)
 	if err != nil {

--- a/shortid.go
+++ b/shortid.go
@@ -1,31 +1,17 @@
 package goinsta
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 )
 
-func leftPad2Len(s string, padStr string, overallLen int) string {
-	var padCountInt int
-	padCountInt = 1 + ((overallLen - len(padStr)) / len(padStr))
-	var retStr = strings.Repeat(padStr, padCountInt) + s
-	return retStr[(len(retStr) - overallLen):]
-}
-
-const base64UrlCharmap = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
-
-func MediaIDFromShortID(code string) (string, error) {
-	strID := ""
-	for i := 0; i < len(code); i++ {
-		base64 := strings.Index(base64UrlCharmap, string(code[i]))
-		str2bin := strconv.FormatInt(int64(base64), 2)
-		sixbits := leftPad2Len(str2bin, "0", 6)
-		strID = strID + sixbits
+func MediaIDFromShortID(code string) string {
+	alphabet := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	media_id := 0
+	for _, letter := range code {
+		media_id = (media_id * 64) + strings.Index(alphabet, string(letter))
 	}
-	result, err := strconv.ParseInt(strID, 2, 64)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%d", result), nil
+	result := strconv.Itoa(media_id)
+
+	return result
 }

--- a/shortid_test.go
+++ b/shortid_test.go
@@ -5,11 +5,8 @@ import (
 )
 
 func TestMediaIDFromShortID(t *testing.T) {
-	mediaID, err := MediaIDFromShortID("BR_repxhx4O")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	mediaID := MediaIDFromShortID("BR_repxhx4O")
+
 	if mediaID != "1477090425239445006" {
 		t.Fatal("Invalid mediaID")
 	}


### PR DESCRIPTION
Fixes build issue

```
./goinsta.go:487:33: conversion from int64 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL    github.com/ahmdrz/goinsta/v2 [build failed]
```
Fixed as suggested, sinc the result should be string with the actual port number.